### PR TITLE
Add dht option to blacklist peers + avoid blacklisted peers in k clos…

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -122,7 +122,7 @@ type HandleQueryFail func(p peer.ID, err error)
 const dialAddressExtendDur time.Duration = time.Minute * 30
 
 // Run crawls dht peers from an initial seed of `startingPeers`
-func (c *Crawler) Run(ctx context.Context, startingPeers []*peer.AddrInfo, handleSuccess HandleQueryResult, handleFail HandleQueryFail) {
+func (c *Crawler) Run(ctx context.Context, startingPeers []peer.AddrInfo, handleSuccess HandleQueryResult, handleFail HandleQueryFail) {
 	jobs := make(chan peer.ID, 1)
 	results := make(chan *queryResult, 1)
 
@@ -157,7 +157,7 @@ func (c *Crawler) Run(ctx context.Context, startingPeers []*peer.AddrInfo, handl
 			continue
 		}
 
-		toDial = append(toDial, ai)
+		toDial = append(toDial, &ai)
 		peersSeen[ai.ID] = struct{}{}
 	}
 

--- a/dht.go
+++ b/dht.go
@@ -115,6 +115,9 @@ type IpfsDHT struct {
 	// DHT protocols we can respond to.
 	serverProtocols []protocol.ID
 
+	// blacklisted peers
+	BlacklistPeers map[peer.ID]struct{}
+
 	auto   ModeOpt
 	mode   mode
 	modeLk sync.Mutex
@@ -196,13 +199,20 @@ func New(ctx context.Context, h host.Host, options ...Option) (*IpfsDHT, error) 
 
 	// check if there is any MessageSender in the cfg
 	if cfg.MessageSenderFunc == nil {
-		dht.msgSender = net.NewMessageSenderImpl(h, dht.protocols)
+		dht.msgSender = net.NewMessageSenderImpl(h, dht.protocols, "")
 	} else {
 		dht.msgSender = cfg.MessageSenderFunc(h, dht.protocols)
 	}
 	dht.protoMessenger, err = pb.NewProtocolMessenger(dht.msgSender)
 	if err != nil {
 		return nil, err
+	}
+
+	// Add the blacklist peers to the DHT
+	if cfg.BlacklistPeers == nil {
+		dht.BlacklistPeers = make(map[peer.ID]struct{})
+	} else {
+		dht.BlacklistPeers = cfg.BlacklistPeers
 	}
 
 	dht.testAddressUpdateProcessing = cfg.TestAddressUpdateProcessing
@@ -860,4 +870,20 @@ func (dht *IpfsDHT) maybeAddAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Dura
 // as described in GetClosestPeers.
 func (dht *IpfsDHT) GetProvidersFromPeer(ctx context.Context, p peer.ID, key multihash.Multihash) ([]*peer.AddrInfo, []*peer.AddrInfo, error) {
 	return dht.protoMessenger.GetProviders(ctx, p, key)
+}
+
+// IsBlacklisted
+func (dht *IpfsDHT) IsBlacklisted(p peer.ID) bool {
+	dht.plk.Lock()
+	defer dht.plk.Unlock()
+
+	_, ok := dht.BlacklistPeers[p]
+	return ok
+}
+
+func (dht *IpfsDHT) BlacklistPeer(p peer.ID) {
+	dht.plk.Lock()
+	defer dht.plk.Unlock()
+
+	dht.BlacklistPeers[p] = struct{}{}
 }

--- a/dht_options.go
+++ b/dht_options.go
@@ -293,15 +293,6 @@ func RoutingTablePeerDiversityFilter(pg peerdiversity.PeerIPGroupFilter) Option 
 	}
 }
 
-// WithCustomMessageSender configures the pb.MessageSender of the IpfsDHT to use the
-// custom implementation of the pb.MessageSender
-func WithCustomMessageSender(initFunc func(h host.Host, protos []protocol.ID) pb.MessageSender) Option {
-	return func(c *dhtcfg.Config) error {
-		c.MessageSenderFunc = initFunc
-		return nil
-	}
-}
-
 // disableFixLowPeersRoutine disables the "fixLowPeers" routine in the DHT.
 // This is ONLY for tests.
 func disableFixLowPeersRoutine(t *testing.T) Option {
@@ -317,6 +308,26 @@ func disableFixLowPeersRoutine(t *testing.T) Option {
 func forceAddressUpdateProcessing(t *testing.T) Option {
 	return func(c *dhtcfg.Config) error {
 		c.TestAddressUpdateProcessing = true
+		return nil
+	}
+}
+
+// --- NEW FEATURE ---
+// WithCustomMessageSender configures the pb.MessageSender of the IpfsDHT to use the
+// custom implementation of the pb.MessageSender
+func WithCustomMessageSender(initFunc func(h host.Host, protos []protocol.ID) pb.MessageSender) Option {
+	return func(c *dhtcfg.Config) error {
+		c.MessageSenderFunc = initFunc
+		return nil
+	}
+}
+
+// --- NEW FEATURE ---
+// WithPeerBlacklist forces the DHT to avoid a certain set of peers.
+// This enables the possibility to remove hydras from participating in our DHT walk and Provide methods
+func WithPeerBlacklist(blacklist map[peer.ID]struct{}) Option {
+	return func(c *dhtcfg.Config) error {
+		c.BlacklistPeers = blacklist
 		return nil
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	EnableValues       bool
 	ProviderStore      providers.ProviderStore
 	QueryPeerFilter    QueryFilterFunc
+	BlacklistPeers     map[peer.ID]struct{}
 	MessageSenderFunc  func(h host.Host, protos []protocol.ID) pb.MessageSender
 
 	RoutingTable struct {


### PR DESCRIPTION
## Motivation 
The motivation of this PR is to enable the possibility of avoiding a particular group of peers when walking the DHT. 
With the final goal of avoiding Hydra-Booster peers when getting the K closest peers + storing the PRs for a given CID.

## Description
The PR includes a modification of the IpfsDHT that avoid a Blacklisted set of peers

## Tasks
[X] add an option on the `IpfsDHT` to specify the blacklisting set of peers
[X] modify the message sender implementation to avoid sending messages to the blacklisted UserAgent