### PR TITLE
Update how lookup metrics are returned 

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -374,7 +374,6 @@ func makeDHT(ctx context.Context, h host.Host, cfg dhtcfg.Config) (*IpfsDHT, err
 }
 
 func makeRtRefreshManager(dht *IpfsDHT, cfg dhtcfg.Config, maxLastSuccessfulOutboundThreshold time.Duration) (*rtrefresh.RtRefreshManager, error) {
-	var hops Hops
 
 	keyGenFnc := func(cpl uint) (string, error) {
 		p, err := dht.routingTable.GenRandPeerID(cpl)
@@ -382,10 +381,9 @@ func makeRtRefreshManager(dht *IpfsDHT, cfg dhtcfg.Config, maxLastSuccessfulOutb
 	}
 
 	queryFnc := func(ctx context.Context, key string) error {
-		_, err := dht.GetClosestPeers(ctx, key, &hops)
+		_, _, err := dht.GetClosestPeers(ctx, key)
 		return err
 	}
-	_ = hops
 
 	r, err := rtrefresh.NewRtRefreshManager(
 		dht.host, dht.routingTable, cfg.RoutingTable.AutoRefresh,

--- a/dht_test.go
+++ b/dht_test.go
@@ -776,10 +776,8 @@ func TestQueryWithEmptyRTShouldNotPanic(t *testing.T) {
 	ps, _ := d.FindProviders(ctx, testCaseCids[0])
 	require.Empty(t, ps)
 
-	var hops Hops
-
 	// GetClosestPeers
-	pc, err := d.GetClosestPeers(ctx, "key", &hops)
+	pc, _, err := d.GetClosestPeers(ctx, "key")
 	require.Nil(t, pc)
 	require.Equal(t, kb.ErrLookupFailure, err)
 
@@ -1443,12 +1441,8 @@ func testFindPeerQuery(t *testing.T,
 	val := "foobar"
 	rtval := kb.ConvertKey(val)
 
-	var hops Hops
-
-	outpeers, err := guy.GetClosestPeers(ctx, val, &hops)
+	outpeers, _, err := guy.GetClosestPeers(ctx, val)
 	require.NoError(t, err)
-
-	_ = hops
 
 	sort.Sort(peer.IDSlice(outpeers))
 
@@ -1477,15 +1471,11 @@ func TestFindClosestPeers(t *testing.T) {
 		connect(t, ctx, dhts[i], dhts[(i+1)%len(dhts)])
 	}
 
-	var hops Hops
-
 	querier := dhts[1]
-	peers, err := querier.GetClosestPeers(ctx, "foo", &hops)
+	peers, _, err := querier.GetClosestPeers(ctx, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	_ = hops
 
 	if len(peers) < querier.beta {
 		t.Fatalf("got wrong number of peers (got %d, expected at least %d)", len(peers), querier.beta)
@@ -1844,15 +1834,11 @@ func TestInvalidKeys(t *testing.T) {
 		connect(t, ctx, dhts[i], dhts[(i+1)%len(dhts)])
 	}
 
-	var hops Hops
-
 	querier := dhts[0]
-	_, err := querier.GetClosestPeers(ctx, "", &hops)
+	_, _, err := querier.GetClosestPeers(ctx, "")
 	if err == nil {
 		t.Fatal("get closest peers should have failed")
 	}
-
-	_ = hops
 
 	_, err = querier.FindProviders(ctx, cid.Cid{})
 	switch err {
@@ -2124,13 +2110,9 @@ func TestPreconnectedNodes(t *testing.T) {
 	require.NoError(t, err)
 	defer h2.Close()
 
-	var hops Hops
-
 	// See if it works
-	peers, err := d2.GetClosestPeers(ctx, "testkey", &hops)
+	peers, _, err := d2.GetClosestPeers(ctx, "testkey")
 	require.NoError(t, err)
-
-	_ = hops
 
 	require.Equal(t, len(peers), 1, "why is there more than one peer?")
 	require.Equal(t, h1.ID(), peers[0], "could not find peer")

--- a/ext_test.go
+++ b/ext_test.go
@@ -68,10 +68,7 @@ func TestHungRequest(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-
-		var hops Hops
-
-		_, err := d.GetClosestPeers(ctx1, testCaseCids[0].KeyString(), &hops)
+		_, _, err := d.GetClosestPeers(ctx1, testCaseCids[0].KeyString())
 		done <- err
 	}()
 

--- a/hops.go
+++ b/hops.go
@@ -16,7 +16,7 @@ type LookupMetrics struct {
 	closestPeers []peer.ID
 }
 
-func newLookupMetrics() *LookupMetrics {
+func NewLookupMetrics() *LookupMetrics {
 	log.Trace("new lookup metrics")
 	return &LookupMetrics{
 		startTime:    time.Now(),

--- a/hops.go
+++ b/hops.go
@@ -9,18 +9,20 @@ import (
 )
 
 type LookupMetrics struct {
-	m         sync.Mutex
-	startTime time.Time
-	tree      map[peer.ID]*hop
-	ogPeers   map[peer.ID]*hop
+	m            sync.Mutex
+	startTime    time.Time
+	tree         map[peer.ID]*hop
+	ogPeers      map[peer.ID]*hop
+	closestPeers []peer.ID
 }
 
 func newLookupMetrics() *LookupMetrics {
 	log.Trace("new lookup metrics")
 	return &LookupMetrics{
-		startTime: time.Now(),
-		tree:      make(map[peer.ID]*hop),
-		ogPeers:   make(map[peer.ID]*hop),
+		startTime:    time.Now(),
+		tree:         make(map[peer.ID]*hop),
+		ogPeers:      make(map[peer.ID]*hop),
+		closestPeers: make([]peer.ID, 0),
 	}
 }
 
@@ -74,12 +76,14 @@ func (l *LookupMetrics) addNewPeers(causePeer peer.ID, p []peer.ID) {
 	}
 }
 
-func (l *LookupMetrics) GetClosestPeers() []peer.ID {
-	closestPeers := make([]peer.ID, 0, len(l.ogPeers))
-	for key, _ := range l.ogPeers {
-		closestPeers = append(closestPeers, key)
+func (l *LookupMetrics) setClosestPeers(cPeers []peer.ID) {
+	for _, p := range cPeers {
+		l.closestPeers = append(l.closestPeers, p)
 	}
-	return closestPeers
+}
+
+func (l *LookupMetrics) GetClosestPeers() []peer.ID {
+	return l.closestPeers
 }
 
 func (l *LookupMetrics) GetHopsForPeerSet(peerSet []peer.ID) int {

--- a/hops.go
+++ b/hops.go
@@ -74,6 +74,14 @@ func (l *LookupMetrics) addNewPeers(causePeer peer.ID, p []peer.ID) {
 	}
 }
 
+func (l *LookupMetrics) GetClosestPeers() []peer.ID {
+	closestPeers := make([]peer.ID, 0, len(l.ogPeers))
+	for key, _ := range l.ogPeers {
+		closestPeers = append(closestPeers, key)
+	}
+	return closestPeers
+}
+
 func (l *LookupMetrics) GetHopsForPeerSet(peerSet []peer.ID) int {
 	return l.getHopsForPeerSet(peerSet)
 }

--- a/hops.go
+++ b/hops.go
@@ -2,34 +2,31 @@ package dht
 
 import (
 	"sync"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	log "github.com/sirupsen/logrus"
 )
 
-// TODO: -- simplyfy the tree by removing queryHops (the begining of the tree is always the key that we are seatching for)
-type Hops struct {
-	Total     int
-	ToClosest int
+type LookupMetrics struct {
+	m         sync.Mutex
+	startTime time.Time
+	tree      map[peer.ID]*hop
+	ogPeers   map[peer.ID]*hop
 }
 
-type queryHops struct {
-	m       sync.Mutex
-	tree    map[peer.ID]*hop
-	ogPeers map[peer.ID]*hop
-}
-
-func newQueryHops() *queryHops {
-	log.Trace("New query hops")
-	return &queryHops{
-		tree:    make(map[peer.ID]*hop),
-		ogPeers: make(map[peer.ID]*hop),
+func newLookupMetrics() *LookupMetrics {
+	log.Trace("new lookup metrics")
+	return &LookupMetrics{
+		startTime: time.Now(),
+		tree:      make(map[peer.ID]*hop),
+		ogPeers:   make(map[peer.ID]*hop),
 	}
 }
 
-func (qh *queryHops) addNewPeers(causePeer peer.ID, p []peer.ID) {
-	qh.m.Lock()
-	defer qh.m.Unlock()
+func (l *LookupMetrics) addNewPeers(causePeer peer.ID, p []peer.ID) {
+	l.m.Lock()
+	defer l.m.Unlock()
 
 	log.WithFields(log.Fields{
 		"cause": causePeer.String(),
@@ -37,15 +34,15 @@ func (qh *queryHops) addNewPeers(causePeer peer.ID, p []peer.ID) {
 	}).Trace("Adding new peers")
 
 	// get parent hop
-	parentHop, ok := qh.searchOgPeer(causePeer)
+	parentHop, ok := l.searchOgPeer(causePeer)
 	if !ok {
-		// if casue peer not in the tree, create new entrance an level 0
+		// if cause peer not in the tree, create new entrance an level 0
 		parentHop = newHop(causePeer)
 		parentHop.original = true
 
 		// add the parent hop to the level 0 tree
-		qh.tree[causePeer] = parentHop
-		qh.ogPeers[causePeer] = parentHop
+		l.tree[causePeer] = parentHop
+		l.ogPeers[causePeer] = parentHop
 	}
 
 	// iter throught the new peers to add to the tree
@@ -58,7 +55,7 @@ func (qh *queryHops) addNewPeers(causePeer peer.ID, p []peer.ID) {
 
 		// check whether there is already an original peer with the same ID in the tree
 		var h *hop
-		_, ok = qh.searchOgPeer(pi)
+		_, ok = l.searchOgPeer(pi)
 
 		// to avoid having an endless loop over links between hops, create non-original childs to fill the tree
 		if ok {
@@ -69,7 +66,7 @@ func (qh *queryHops) addNewPeers(causePeer peer.ID, p []peer.ID) {
 			// if the there isn't a peer with the same PeerId, we create an original one
 			h = newHop(pi)
 			h.original = true
-			qh.ogPeers[pi] = h
+			l.ogPeers[pi] = h
 
 		}
 		// link always the child hop to the parent hop
@@ -77,10 +74,14 @@ func (qh *queryHops) addNewPeers(causePeer peer.ID, p []peer.ID) {
 	}
 }
 
+func (l *LookupMetrics) GetHopsForPeerSet(peerSet []peer.ID) int {
+	return l.getHopsForPeerSet(peerSet)
+}
+
 // means go through the tree len(peerSet) times to get the total of hops to discover the peers
-func (qh *queryHops) getHopsForPeerSet(peerSet []peer.ID) int {
-	qh.m.Lock()
-	defer qh.m.Unlock()
+func (l *LookupMetrics) getHopsForPeerSet(peerSet []peer.ID) int {
+	l.m.Lock()
+	defer l.m.Unlock()
 
 	// although the hop gives you the minum distance to the peer,
 	// whe want the biggest one of those shortest distances
@@ -89,7 +90,7 @@ func (qh *queryHops) getHopsForPeerSet(peerSet []peer.ID) int {
 	// iter through the peer set to see the sortest depth at when we found it
 	for _, p := range peerSet {
 		var shortestHop int
-		for _, hop := range qh.tree {
+		for _, hop := range l.tree {
 			// if the target peer is already in the initial hop list, keep searching for the rest of peers (shortest distance)
 			if p == hop.causePeer {
 				continue
@@ -121,15 +122,19 @@ func (qh *queryHops) getHopsForPeerSet(peerSet []peer.ID) int {
 
 }
 
-func (qh *queryHops) getHops() int {
-	qh.m.Lock()
-	defer qh.m.Unlock()
+func (l *LookupMetrics) GetHops() int {
+	return l.getHops()
+}
+
+func (l *LookupMetrics) getHops() int {
+	l.m.Lock()
+	defer l.m.Unlock()
 
 	//peerCache := make(map[peer.ID]bool)
 	var maxHops int
 
 	// go through the entire tree checking which is the largest branch
-	for _, v := range qh.tree {
+	for _, v := range l.tree {
 		//	peerCache[v.causePeer] = true            // add to the cache the seed peers
 		auxHops := v.getNumberOfHops() // no previous hops since we are at parent
 		if auxHops > maxHops {
@@ -139,39 +144,24 @@ func (qh *queryHops) getHops() int {
 	return maxHops // the first hop is always our self-host peer id, so don't count it
 }
 
-func (qh *queryHops) searchOgPeer(peerID peer.ID) (*hop, bool) {
+func (l *LookupMetrics) searchOgPeer(peerID peer.ID) (*hop, bool) {
 	log.WithFields(log.Fields{
 		"peer": peerID.String(),
 	}).Trace("searching peer")
 
 	// iter through the ogPeers tree (optimized version)
-	h, ok := qh.ogPeers[peerID]
+	h, ok := l.ogPeers[peerID]
 	return h, ok
-
-	// --- Depecated: was adding to much overhead when adding pers ---
-	//
-	// // iter through the number of initial hops
-	// for p, h := range qh.tree {
-	// 	if p == peerID && h.original {
-	// 		return h, true
-	// 	}
-	// 	auxH, ok := h.searchPeer(peerID)
-	// 	if ok {
-	// 		if !auxH.original {
-	// 			log.Panic("pointer to non-original hop has been received at QueryHops")
-	// 		}
-	// 		return auxH, true
-	// 	}
-	// }
-	// // if previosu search didn't succeed, return failure searching
-	// return nil, false
 }
 
 type hop struct {
-	m         sync.Mutex
-	causePeer peer.ID
-	original  bool // identify if this peer is a original of existing one (came later in the lookup)
-	hops      map[peer.ID]*hop
+	m sync.Mutex
+
+	firstReportTime time.Time `json:"first-report-time"` // Time when the peer was first reported or tracked in the tree
+
+	causePeer peer.ID          `json:"cause-peer"` // peer that we contacted in the specific hop
+	original  bool             `json:"original"`   // identify if this peer is a original of existing one (came later in the lookup)
+	hops      map[peer.ID]*hop `json:"hops"`       // subsecuent hops from this same one
 }
 
 func newHop(causePeer peer.ID) *hop {
@@ -180,9 +170,10 @@ func newHop(causePeer peer.ID) *hop {
 	}).Trace("new hop")
 
 	return &hop{
-		causePeer: causePeer,
-		original:  false,
-		hops:      make(map[peer.ID]*hop),
+		firstReportTime: time.Now(),
+		causePeer:       causePeer,
+		original:        false,
+		hops:            make(map[peer.ID]*hop),
 	}
 }
 
@@ -191,7 +182,7 @@ func (h *hop) len() int {
 }
 
 // --- Depecated: was adding to much overhead when adding pers ---
-// moved to a OgPeers cache in queryHops
+// moved to a OgPeers cache in LookupMetrics
 func (h *hop) searchPeer(peerID peer.ID) (*hop, bool) {
 	h.m.Lock()
 	defer h.m.Unlock()

--- a/hops_test.go
+++ b/hops_test.go
@@ -65,7 +65,7 @@ func TestHop(t *testing.T) {
 	require.Equal(t, 0, shortestHop)
 }
 
-func TestHopsQuery(t *testing.T) {
+func TestLookupMetrics(t *testing.T) {
 
 	//  schema:
 	// peer 0 	-- peer 2	-- peer 6	-- peer 7
@@ -102,7 +102,7 @@ func TestHopsQuery(t *testing.T) {
 	}
 
 	// generate the parent queryHop
-	qHop := newQueryHops()
+	qHop := newLookupMetrics()
 
 	// ---- level 1 and 2 of the tree ----
 	// add peer 2 and 3 as child hops from 0

--- a/lookup.go
+++ b/lookup.go
@@ -57,5 +57,8 @@ func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) ([]peer.ID,
 		dht.routingTable.ResetCplRefreshedAtForID(kb.ConvertKey(key), time.Now())
 	}
 
+	// add the set of closest peers to the lookupMetrics
+	lookupRes.lookupMetrics.setClosestPeers(lookupRes.peers)
+
 	return lookupRes.peers, lookupRes.lookupMetrics, ctx.Err()
 }

--- a/lookup.go
+++ b/lookup.go
@@ -57,7 +57,6 @@ func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) ([]peer.ID,
 		dht.routingTable.ResetCplRefreshedAtForID(kb.ConvertKey(key), time.Now())
 	}
 
-	// add the set of closest peers to the lookupMetrics
 	lookupRes.lookupMetrics.setClosestPeers(lookupRes.peers)
 
 	return lookupRes.peers, lookupRes.lookupMetrics, ctx.Err()

--- a/query.go
+++ b/query.go
@@ -168,7 +168,7 @@ func (dht *IpfsDHT) runQuery(ctx context.Context, target string, queryFn queryFn
 		ctx:           ctx,
 		dht:           dht,
 		queryPeers:    qpeerset.NewQueryPeerset(target),
-		lookupMetrics: newLookupMetrics(),
+		lookupMetrics: NewLookupMetrics(),
 		seedPeers:     seedPeers,
 		peerTimes:     make(map[peer.ID]time.Duration),
 		terminated:    false,

--- a/query.go
+++ b/query.go
@@ -12,7 +12,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	pstore "github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/routing"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/google/uuid"
 	"github.com/libp2p/go-libp2p-kad-dht/qpeerset"
@@ -146,13 +145,6 @@ processFollowUp:
 		for i := followupsCompleted; i < len(queryPeers); i++ {
 			<-doneCh
 		}
-	}
-
-	// add the number of totalHops to the pointer given by the caller
-	*hops = *lookupRes.hops
-
-	if hops.Total == 0 && hops.ToClosest == 0 {
-		log.Error("no lookup?")
 	}
 
 	return lookupRes, nil

--- a/query_test.go
+++ b/query_test.go
@@ -50,13 +50,11 @@ func TestRTEvictionOnFailedQuery(t *testing.T) {
 		return nil
 	}))
 
-	var hops Hops
-
 	// failed queries should remove the peers from the RT
-	_, err := d1.GetClosestPeers(ctx, "test", &hops)
+	_, _, err := d1.GetClosestPeers(ctx, "test")
 	require.NoError(t, err)
 
-	_, err = d2.GetClosestPeers(ctx, "test", &hops)
+	_, _, err = d2.GetClosestPeers(ctx, "test")
 	require.NoError(t, err)
 
 	require.NoError(t, tu.WaitFor(ctx, func() error {
@@ -102,10 +100,8 @@ func TestRTAdditionOnSuccessfulQuery(t *testing.T) {
 		return nil
 	}))
 
-	var hops Hops
-
 	// but when d3 queries d2, d1 and d3 discover each other
-	_, err := d3.GetClosestPeers(ctx, "something", &hops)
+	_, _, err := d3.GetClosestPeers(ctx, "something")
 	require.NoError(t, err)
 	require.NoError(t, tu.WaitFor(ctx, func() error {
 		if !checkRoutingTable(d1, d3) {


### PR DESCRIPTION
Modifies the interface of `dht.GetClosestPeers()` to expose the entire `LookupMetrics` to the requester